### PR TITLE
Add Dokka plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,8 @@ lint:
 run-lint-rules:
 	./gradlew ktlintFormat
 
+documentation:
+	./gradlew dokka
+
 publish-test-lib-prod: clean
 	./gradlew build publish --stacktrace

--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ Copy and paste the file **github_credentials.properties.sample** and rename it t
 **Important:** The file **github_credentials.properties** can not be committed.
 
 ### Documentation
-Example usages can be found as comments on top of every class and function.
+Example usages can be found as comments on top of every class and function. For a complete report with all functions run the following command:
+
+    make documentation
+
+The report will be available at `testcommons/build/dokka/testcommons/index.html`
 
 ## How to contribute
 You can contribute submitting [pull requests](https://github.com/natura-cosmeticos/Nat-Test-Commons/pulls).

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,8 @@
 
 buildscript {
     ext.kotlin_version = '1.3.72'
-    ext.android_tools_gradle = '3.5.1'
+    ext.android_tools_gradle_version = '3.5.1'
+    ext.maven_gradle_version = '2.1'
     ext.dokka_version = '0.10.1'
 
     repositories {
@@ -11,10 +12,9 @@ buildscript {
 
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:$android_tools_gradle"
+        classpath "com.android.tools.build:gradle:$android_tools_gradle_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
+        classpath "com.github.dcendents:android-maven-gradle-plugin:$maven_gradle_version"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     ext.kotlin_version = '1.3.72'
     ext.android_tools_gradle = '3.5.1'
+    ext.dokka_version = '0.10.1'
 
     repositories {
         google()
@@ -14,6 +15,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokka_version"
     }
 }
 

--- a/testcommons/build.gradle
+++ b/testcommons/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'org.jetbrains.dokka'
 apply from: "$rootDir/tools/publish.gradle"
 apply from: "$rootDir/tools/ktlint.gradle"
 


### PR DESCRIPTION
This PR adds the [Dokka plugin](https://github.com/Kotlin/dokka).

With this plugin, users that want to read all the documentation in one place can do so by running a script.